### PR TITLE
Handle missing runtime dependencies in Streamlit app

### DIFF
--- a/streamlit-gantt/app.py
+++ b/streamlit-gantt/app.py
@@ -4,9 +4,25 @@ from __future__ import annotations
 from typing import List, Optional
 
 import pandas as pd
-import plotly.io as pio
 import streamlit as st
-from streamlit_plotly_events import plotly_events
+
+try:
+    import plotly.io as pio
+except ModuleNotFoundError:  # pragma: no cover - run-time safeguard
+    st.error(
+        "Plotly が見つかりませんでした。アプリを実行する前に "
+        "`pip install -r streamlit-gantt/requirements.txt` を実行してください。"
+    )
+    st.stop()
+
+try:
+    from streamlit_plotly_events import plotly_events
+except ModuleNotFoundError:  # pragma: no cover - run-time safeguard
+    st.error(
+        "streamlit-plotly-events が見つかりませんでした。アプリを実行する前に "
+        "`pip install -r streamlit-gantt/requirements.txt` を実行してください。"
+    )
+    st.stop()
 
 from components import editor, filters, gantt
 from utils import state as state_utils


### PR DESCRIPTION
## Summary
- ensure the Streamlit app stops gracefully when Plotly is not installed and informs the user how to install dependencies
- add the same safeguard for streamlit-plotly-events to avoid confusing runtime crashes

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68d8b614f6d483239d0a639864826582