### PR TITLE
Fix tests by configuring import path for utils module

### DIFF
--- a/streamlit-gantt/tests/conftest.py
+++ b/streamlit-gantt/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Pytest configuration for path resolution."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the application package root (containing ``utils`` and other modules)
+# is importable when running tests from the repository root. This mirrors the
+# path configuration that ``streamlit run`` performs automatically when
+# launching the app from the ``streamlit-gantt`` directory.
+APP_ROOT = Path(__file__).resolve().parents[1]
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))


### PR DESCRIPTION
## Summary
- ensure pytest adds the streamlit application directory to sys.path so internal modules resolve

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8b6b73b8c8323a56d303f3778cabb